### PR TITLE
Set CMAKE_POLICY_VERSION_MINIMUM to support CMake 4

### DIFF
--- a/casclib-sys/build.rs
+++ b/casclib-sys/build.rs
@@ -12,17 +12,17 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     {
-      cfg.cxxflag("-D UNICODE")
-        .cxxflag("-D _UNICODE")
-        .cxxflag("-D CASC_UNICODE")
-        .cxxflag("-D CASCLIB_UNICODE");        
-    
+        cfg.cxxflag("-D UNICODE")
+            .cxxflag("-D _UNICODE")
+            .cxxflag("-D CASC_UNICODE")
+            .cxxflag("-D CASCLIB_UNICODE");
     }
 
     // Builds CascLib using cmake
     let dst = cfg
         .define("CASC_BUILD_SHARED_LIB", "OFF")
         .define("CASC_BUILD_STATIC_LIB", "ON")
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
         .build();
 
     let lib = dst.join("lib");


### PR DESCRIPTION
The current build fails on cmake 4+ as casclib has `cmake_minimum_required(VERSION 3.2)`. CMake 4+ only supports 3.13 and above by default. Adding the `CMAKE_POLICY_VERSION_MINIMUM=3.5` allows cmake 4+ to attempt to build anyway.